### PR TITLE
Fix flaky test_everything.py::MessageFactoryTestCase::test_format_time_default

### DIFF
--- a/test_everything.py
+++ b/test_everything.py
@@ -223,6 +223,7 @@ class MessageFactoryTestCase(unittest.TestCase):
         self._setlocale('fa_IR.UTF-8')
 
     def test_format_time_default(self):
+        os.environ['LANG'] = 'en'
         os.environ['LANGUAGE'] = 'en'
         timestr = self.msg_factory.format_time('20170603T191148.000Z')
         self.assertEqual(timestr, 'Sat, 03 Jun 2017 19:11:48')


### PR DESCRIPTION
This PR aims to fix the flaky `test_everything.py::MessageFactoryTestCase::test_format_time_default`.
The test can pass when running the whole test suite for the first time, but fail when running the suite for multiple times.
The polluter turns out to be `test_format_time_fa` in the same test class, which sets the value of `os.environ['LANG']` to `'fa_IR'`.
The function `formatters.py::format_time` will not return default time if `os.environ['LANG'] = 'fa' or os.environ['LANGUAGE'] = 'fa_IR' or locale.getlocale()[0]='fa_IR.UTF-8'`.
While `locale` is set to `'en_US.UTF-8'` in `MessageFactoryTestCase::setUp`, `os.environ` also needs to be reset to fix the test.
The failure can be reproduced by:
`pip install pytest-flakefinder`
`pytest --flake-finder --flake-runs=2 test_everything.py::MessageFactoryTestCase`